### PR TITLE
Add supervised contrastive Swin UNETR pretraining

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Currently it includes the **ResEnc-L** [[a]((https://arxiv.org/abs/2410.23132)),
 6. [SimMIM (SimMIM)](https://openaccess.thecvf.com/content/CVPR2022/html/Xie_SimMIM_A_Simple_Framework_for_Masked_Image_Modeling_CVPR_2022_paper.html)
 7. [SwinUNETR pre-training  (SwinUNETR)](https://arxiv.org/abs/2111.14791)
 8. [SimCLR (SimCLR)](https://arxiv.org/abs/2002.05709)
+9. Supervised contrastive SwinUNETR pre-training (SwinSupCon)
 
 -----
 ### Complimentary resources:
@@ -146,8 +147,11 @@ The `trainer` determines pre-training method and architecture, the `dataset` the
 
 An exemplary pre-training call for a 4xGPU ResEnc-L MAE pre-training would be:
 `python ./nnssl/run/run_training.py ID CONFIG -tr BaseMAETrainer_BS8 -p nnsslPlans -num_gpus 4`
-or 
+or
 `nnssl_train ID CONFIG -tr BaseMAETrainer_BS8 -p nnsslPlans -num_gpus 4`
+
+An example call for the supervised contrastive SwinUNETR pre-training is:
+`nnssl_train ID CONFIG -tr SwinUNETRSupConTrainer_BS8 -p nnsslPlans -num_gpus 4`
 
 Note: Due to the lack of e.g. linear-probing for segmentation, no metrics aside from the train and validation loss are tracked during pre-training.
 

--- a/src/nnssl/ssl_data/dataloading/__init__.py
+++ b/src/nnssl/ssl_data/dataloading/__init__.py
@@ -1,0 +1,2 @@
+from .data_loader_3d import nnsslDataLoader3D, nnsslAnatDataLoader3D, nnsslCenterCropDataLoader3D, nnsslIndexableCenterCropDataLoader3D
+from .data_loader_3d_centroid import nnsslDataLoader3DCentroid

--- a/src/nnssl/ssl_data/dataloading/data_loader_3d_centroid.py
+++ b/src/nnssl/ssl_data/dataloading/data_loader_3d_centroid.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Union, List, Tuple
+
+from .data_loader_3d import nnsslDataLoader3D
+from nnssl.data.dataloading.dataset import nnSSLDatasetBlosc2
+
+
+class nnsslDataLoader3DCentroid(nnsslDataLoader3D):
+    """Extension of :class:`nnsslDataLoader3D` that also returns patch centroids."""
+
+    def __init__(
+        self,
+        data: nnSSLDatasetBlosc2,
+        batch_size: int,
+        patch_size: Union[List[int], Tuple[int, ...], np.ndarray],
+        final_patch_size: Union[List[int], Tuple[int, ...], np.ndarray],
+        sampling_probabilities: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+        pad_sides: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+    ) -> None:
+        super().__init__(data, batch_size, patch_size, final_patch_size, sampling_probabilities, pad_sides)
+
+    def generate_train_batch(self):
+        selected_keys = self.get_indices()
+        data_all = np.zeros(self.data_shape, dtype=np.float32)
+        anon_all = np.zeros(self.data_shape, dtype=np.uint8)
+        centroids = np.zeros((len(selected_keys), 3), dtype=np.float32)
+        case_properties = []
+
+        for j, i in enumerate(selected_keys):
+            data, anon, anat, properties = self._data[i]
+            if anon is None:
+                anon = np.zeros(data.shape, dtype=np.uint8)
+            case_properties.append(properties)
+
+            shape = data.shape[1:]
+            dim = len(shape)
+            bbox_lbs, bbox_ubs = self.get_bbox(shape)
+
+            valid_bbox_lbs = [max(0, bbox_lbs[d]) for d in range(dim)]
+            valid_bbox_ubs = [min(shape[d], bbox_ubs[d]) for d in range(dim)]
+
+            this_slice = (
+                [slice(0, data.shape[0])] + [slice(l, u) for l, u in zip(valid_bbox_lbs, valid_bbox_ubs)]
+            )
+            data = data[tuple(this_slice)]
+            anon = anon[tuple(this_slice)]
+
+            padding = [(-min(0, bbox_lbs[d]), max(bbox_ubs[d] - shape[d], 0)) for d in range(dim)]
+            data_all[j] = np.pad(data, ((0, 0), *padding), "constant", constant_values=0)
+            anon_all[j] = np.pad(anon, ((0, 0), *padding), "constant", constant_values=0)
+
+            spacing = np.array(properties.get("spacing", (1.0, 1.0, 1.0)), dtype=float)
+            center_voxel = np.array(bbox_lbs) + np.array(self.patch_size) / 2.0
+            centroids[j] = center_voxel * spacing
+
+        return {
+            "data": data_all,
+            "seg": anon_all,
+            "centroids": centroids,
+            "properties": case_properties,
+            "keys": selected_keys,
+        }

--- a/src/nnssl/ssl_data/dataloading/swin_unetr_supcon_transform.py
+++ b/src/nnssl/ssl_data/dataloading/swin_unetr_supcon_transform.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .swin_unetr_transform import SwinUNETRTransform
+
+
+class SwinUNETRSupConTransform(SwinUNETRTransform):
+    """Transform that keeps patch centroids for supervised contrastive learning."""
+
+    def __init__(self, data_key: str = "data", centroid_key: str = "centroids"):
+        super().__init__(data_key)
+        self.centroid_key = centroid_key
+
+    def __call__(self, **data_dict):
+        centroids = data_dict.get(self.centroid_key)
+        res = super().__call__(**data_dict)
+        if centroids is not None:
+            res[self.centroid_key] = centroids
+        return res

--- a/src/nnssl/training/loss/swinunetr_supcon_loss.py
+++ b/src/nnssl/training/loss/swinunetr_supcon_loss.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class SpatialContrastLoss(nn.Module):
+    """Contrastive loss using spatial proximity to define positives."""
+
+    def __init__(self, batch_size: int, device: torch.device, temperature: float = 0.5, pos_threshold_mm: float = 30.0):
+        super().__init__()
+        self.batch_size = batch_size
+        self.register_buffer("temp", torch.tensor(temperature).to(device))
+        self.pos_threshold = pos_threshold_mm
+        self.register_buffer("eps", torch.tensor(1e-8))
+
+    def forward(self, features: torch.Tensor, coords_mm: torch.Tensor) -> torch.Tensor:
+        z = F.normalize(features, dim=1)
+        sim = F.cosine_similarity(z.unsqueeze(1), z.unsqueeze(0), dim=2)
+
+        dist = torch.cdist(coords_mm, coords_mm)
+        device = features.device
+        eye = torch.eye(dist.shape[0], device=device, dtype=torch.bool)
+        pos_mask = (dist < self.pos_threshold) & (~eye)
+
+        exp_sim = torch.exp(sim / self.temp) * (~eye)
+        denom = exp_sim.sum(dim=1)
+        numer = (exp_sim * pos_mask.float()).sum(dim=1)
+        loss = -torch.log((numer + self.eps) / (denom + self.eps))
+        return loss.mean()
+
+
+class SwinUNETRSupConLoss(nn.Module):
+    def __init__(self, batch_size: int, device: torch.device, rec_loss_weight: float, contrast_loss_weight: float, rot_loss_weight: float, pos_threshold_mm: float = 30.0):
+        super().__init__()
+        self.rec_loss = nn.L1Loss().to(device)
+        self.contrast_loss = SpatialContrastLoss(batch_size, device, pos_threshold_mm=pos_threshold_mm).to(device)
+        self.rot_loss = nn.CrossEntropyLoss().to(device)
+
+        self.rec_loss_weight = rec_loss_weight
+        self.contrast_loss_weight = contrast_loss_weight
+        self.rot_loss_weight = rot_loss_weight
+
+    def __call__(self, rotations_pred: torch.Tensor, rotations: torch.Tensor, contrast: torch.Tensor, coords_mm: torch.Tensor, reconstructions: torch.Tensor, imgs_rotated: torch.Tensor) -> torch.Tensor:
+        rec_loss = self.rec_loss(reconstructions, imgs_rotated)
+        contrast_loss = self.contrast_loss(contrast, coords_mm)
+        rot_loss = self.rot_loss(rotations_pred, rotations)
+        return (
+            self.rec_loss_weight * rec_loss
+            + self.contrast_loss_weight * contrast_loss
+            + self.rot_loss_weight * rot_loss
+        )

--- a/src/nnssl/training/nnsslTrainer/swinunetr_pretrain/SwinUNETRSupConTrainer.py
+++ b/src/nnssl/training/nnsslTrainer/swinunetr_pretrain/SwinUNETRSupConTrainer.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import torch
+from typing_extensions import override
+
+from nnssl.ssl_data.dataloading.swin_unetr_supcon_transform import SwinUNETRSupConTransform
+from torch import autocast
+from nnssl.utilities.helpers import dummy_context
+from nnssl.ssl_data.dataloading.data_loader_3d_centroid import nnsslDataLoader3DCentroid
+from nnssl.training.loss.swinunetr_supcon_loss import SwinUNETRSupConLoss
+from nnssl.training.nnsslTrainer.swinunetr_pretrain.SwinUNETRTrainer import SwinUNETRTrainer
+from nnssl.experiment_planning.experiment_planners.plan import Plan
+from batchgenerators.dataloading.single_threaded_augmenter import SingleThreadedAugmenter
+from nnssl.ssl_data.limited_len_wrapper import LimitedLenWrapper
+from nnssl.utilities.default_n_proc_DA import get_allowed_n_proc_DA
+from batchgenerators.transforms.abstract_transforms import AbstractTransform, Compose
+from batchgenerators.transforms.utility_transforms import NumpyToTensor
+
+
+class SwinUNETRSupConTrainer(SwinUNETRTrainer):
+    """Swin UNETR trainer using supervised contrastive learning based on spatial proximity."""
+
+    @override
+    def build_loss(self):
+        return SwinUNETRSupConLoss(
+            self.batch_size,
+            self.device,
+            self.rec_loss_weight,
+            self.contrast_loss_weight,
+            self.rot_loss_weight,
+        )
+
+    @override
+    def get_plain_dataloaders(self, initial_patch_size):
+        dataset_tr, dataset_val = self.get_tr_and_val_datasets()
+        dl_tr = nnsslDataLoader3DCentroid(
+            dataset_tr,
+            self.batch_size,
+            initial_patch_size,
+            self.config_plan.patch_size,
+            sampling_probabilities=None,
+            pad_sides=None,
+        )
+        dl_val = nnsslDataLoader3DCentroid(
+            dataset_val,
+            self.batch_size,
+            self.config_plan.patch_size,
+            self.config_plan.patch_size,
+            sampling_probabilities=None,
+            pad_sides=None,
+        )
+        return dl_tr, dl_val
+
+    @staticmethod
+    def get_training_transforms() -> AbstractTransform:
+        tr_transforms = [
+            SwinUNETRSupConTransform(),
+            NumpyToTensor(cast_to="float", keys=["imgs_rotated", "imgs_rotated_cutout", "centroids"]),
+            NumpyToTensor(cast_to="long", keys="rotations"),
+        ]
+        return Compose(tr_transforms)
+
+    @override
+    def get_dataloaders(self):
+        tr_transforms = self.get_training_transforms()
+        val_transforms = self.get_validation_transforms()
+
+        dl_tr, dl_val = self.get_plain_dataloaders(initial_patch_size=self.config_plan.patch_size)
+
+        allowed_num_processes = get_allowed_n_proc_DA()
+        if allowed_num_processes == 0:
+            mt_gen_train = SingleThreadedAugmenter(dl_tr, tr_transforms)
+            mt_gen_val = SingleThreadedAugmenter(dl_val, val_transforms)
+        else:
+            mt_gen_train = LimitedLenWrapper(
+                self.num_iterations_per_epoch,
+                data_loader=dl_tr,
+                transform=tr_transforms,
+                num_processes=allowed_num_processes,
+                num_cached=6,
+                seeds=None,
+                pin_memory=self.device.type == "cuda",
+                wait_time=0.02,
+            )
+            mt_gen_val = LimitedLenWrapper(
+                self.num_val_iterations_per_epoch,
+                data_loader=dl_val,
+                transform=val_transforms,
+                num_processes=max(1, allowed_num_processes // 2),
+                num_cached=3,
+                seeds=None,
+                pin_memory=self.device.type == "cuda",
+                wait_time=0.02,
+            )
+        return mt_gen_train, mt_gen_val
+
+    @override
+    def train_step(self, batch: dict) -> dict:
+        imgs1_rotated, imgs2_rotated = batch["imgs_rotated"]
+        rotations1, rotations2 = batch["rotations"]
+        imgs1_rotated_cutout, imgs2_rotated_cutout = batch["imgs_rotated_cutout"]
+        centroids = batch["centroids"]
+
+        imgs_rotated = torch.cat([imgs1_rotated, imgs2_rotated], dim=0)
+        rotations = torch.cat([rotations1, rotations2], dim=0)
+        imgs_rotated_cutout = torch.cat([imgs1_rotated_cutout, imgs2_rotated_cutout], dim=0)
+        centroids = centroids.repeat(2, 1)
+
+        imgs_rotated = imgs_rotated.to(self.device, non_blocking=True)
+        rotations = rotations.to(self.device, non_blocking=True)
+        imgs_rotated_cutout = imgs_rotated_cutout.to(self.device, non_blocking=True)
+        centroids = centroids.to(self.device, non_blocking=True)
+
+        self.optimizer.zero_grad(set_to_none=True)
+        with autocast(self.device.type, enabled=True) if self.device.type == "cuda" else dummy_context():
+            rotations_pred, contrast_pred, reconstructions = self.network(imgs_rotated_cutout)
+            l = self.loss(rotations_pred, rotations, contrast_pred, centroids, reconstructions, imgs_rotated)
+
+        if self.grad_scaler is not None:
+            self.grad_scaler.scale(l).backward()
+            self.grad_scaler.unscale_(self.optimizer)
+            torch.nn.utils.clip_grad_norm_(self.network.parameters(), 12)
+            self.grad_scaler.step(self.optimizer)
+            self.grad_scaler.update()
+        else:
+            l.backward()
+            torch.nn.utils.clip_grad_norm_(self.network.parameters(), 12)
+            self.optimizer.step()
+        return {"loss": l.detach().cpu().numpy()}
+
+
+class SwinUNETRSupConTrainer_BS2(SwinUNETRSupConTrainer):
+    def __init__(
+        self,
+        plan: Plan,
+        configuration_name: str,
+        fold: int,
+        pretrain_json: dict,
+        device: torch.device = torch.device("cuda"),
+    ):
+        super().__init__(plan, configuration_name, fold, pretrain_json, device)
+        self.total_batch_size = 2
+
+
+class SwinUNETRSupConTrainer_BS8(SwinUNETRSupConTrainer):
+    def __init__(
+        self,
+        plan: Plan,
+        configuration_name: str,
+        fold: int,
+        pretrain_json: dict,
+        device: torch.device = torch.device("cuda"),
+    ):
+        super().__init__(plan, configuration_name, fold, pretrain_json, device)
+        self.total_batch_size = 8
+
+    @override
+    def validation_step(self, batch: dict) -> dict:
+        imgs1_rotated, imgs2_rotated = batch["imgs_rotated"]
+        rotations1, rotations2 = batch["rotations"]
+        imgs1_rotated_cutout, imgs2_rotated_cutout = batch["imgs_rotated_cutout"]
+        centroids = batch["centroids"]
+
+        imgs_rotated = torch.cat([imgs1_rotated, imgs2_rotated], dim=0)
+        rotations = torch.cat([rotations1, rotations2], dim=0)
+        imgs_rotated_cutout = torch.cat([imgs1_rotated_cutout, imgs2_rotated_cutout], dim=0)
+        centroids = centroids.repeat(2, 1)
+
+        imgs_rotated = imgs_rotated.to(self.device, non_blocking=True)
+        rotations = rotations.to(self.device, non_blocking=True)
+        imgs_rotated_cutout = imgs_rotated_cutout.to(self.device, non_blocking=True)
+        centroids = centroids.to(self.device, non_blocking=True)
+
+        with torch.no_grad():
+            with autocast(self.device.type, enabled=True) if self.device.type == "cuda" else dummy_context():
+                rotations_pred, contrast_pred, reconstructions = self.network(imgs_rotated_cutout)
+                l = self.loss(rotations_pred, rotations, contrast_pred, centroids, reconstructions, imgs_rotated)
+
+        return {"loss": l.detach().cpu().numpy()}

--- a/src/nnssl/training/nnsslTrainer/swinunetr_pretrain/__init__.py
+++ b/src/nnssl/training/nnsslTrainer/swinunetr_pretrain/__init__.py
@@ -1,0 +1,7 @@
+from .SwinUNETRTrainer import SwinUNETRTrainer, SwinUNETRTrainer_BS2, SwinUNETRTrainer_BS8
+from .SwinUNETREvaTrainer import SwinUNETREvaTrainer, SwinUNETREvaTrainer_BS8
+from .SwinUNETRSupConTrainer import (
+    SwinUNETRSupConTrainer,
+    SwinUNETRSupConTrainer_BS2,
+    SwinUNETRSupConTrainer_BS8,
+)


### PR DESCRIPTION
## Summary
- implement dataloader returning patch centroids
- implement transform preserving centroids
- add spatial contrastive loss and trainer for supervised contrastive Swin UNETR
- expose CLI classes for BS2/BS8 variants
- document CLI usage for the new pre-training method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_b_683de0f772ec832497e4a7b471dbcfb8